### PR TITLE
Add brew formulae for ligo

### DIFF
--- a/Formula/ligo.rb
+++ b/Formula/ligo.rb
@@ -1,0 +1,39 @@
+class Ligo < Formula
+  desc "A friendly Smart Contract Language for Tezos"
+  homepage "https://ligolang.org/"
+
+  version "0.19.0"
+  url "https://gitlab.com/ligolang/ligo.git", :tag => Ligo.version, :shallow => true
+
+  bottle do
+  end
+
+  build_dependencies = %w[opam rust hidapi pkg-config]
+  build_dependencies.each do |dependency|
+    depends_on dependency => :build
+  end
+
+  dependencies = %w[gmp libev libffi]
+  dependencies.each do |dependency|
+    depends_on dependency
+  end
+
+  def install
+    system "opam",
+     "init",
+     "--bare",
+     "--auto-setup",
+     "--disable-sandboxing"
+
+    # we want to be sure that all steps run in the same shell with evaled opam config
+    ENV["LIGO_VERSION"] = Ligo.version
+    system "scripts/setup_switch.sh"
+    system ["eval $(opam config env)", "scripts/install_vendors_deps.sh", "scripts/build_ligo_local.sh"].join(" && ")
+
+    bin.mkpath
+    bin.install "_build/install/default/bin/ligo"
+  end
+  test do
+    system "#{bin}/ligo", "--help"
+  end
+end

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2021 contributors
+MIT License Copyright (c) LigoLANG SASU
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+Copyright 2021 contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Ligo tap
+
+A [Homebrew](https://brew.sh/) Tap For [Ligo](https://ligolang.org/).
+
+## Install
+
+To install this formula, run:
+
+```
+brew tap ligolang/ligo
+```
+## Usage
+
+```
+ligo --help
+```
+
+## License
+
+[MIT](./LICENSE.md)
+brew install ligo
+```


### PR DESCRIPTION
Problem: At the moment ligo lacks a convenient way for installation on
macOS.

Solution: The most commonly used package manager for macOS is brew, so
we're providing a brew formula for building and installing ligo
executable. Note that in order to skip building step binary bottles have
to be built for all target macOS versions, then these bottles need to be
uploaded somewhere and listed in the 'bottle' attribute along with their
sha256 hashes in the formula.