### PR TITLE
Add Github Actions CI for checking brew formula and building catalina bottles

### DIFF
--- a/.github/workflows/brew-test.yml
+++ b/.github/workflows/brew-test.yml
@@ -1,0 +1,42 @@
+# Builds and runs checks on the brew formula.
+# Based on: https://github.com/Homebrew/brew/blob/3.2.2/Library/Homebrew/dev-cmd/tap-new.rb#L63
+
+# To run the checks locally:
+# $ brew tap ligolang/homebrew-ligo
+# $ cd "$(brew --repo ligolang/ligo)"
+# $ git fetch
+# $ git checkout <branch>
+# $ git reset --hard @{upstream}
+# Then you can run `brew test-bot` commands by adding '--tap ligolang/ligo' flag
+
+name: test brew formula
+on:
+  push:
+    branches: [master]
+  pull_request:
+jobs:
+  brew-test:
+    runs-on: macos-10.15
+    steps:
+      # Installs/updates homebrew itself, and taps for this repo, `homebrew-core` and `homebrew-test-bot`
+      - name: Set up homebrew taps
+        id: set-up-homebrew
+        uses: homebrew/actions/setup-homebrew@master
+
+      - run: brew test-bot --only-cleanup-before
+
+      - run: brew test-bot --only-setup
+
+      # Checks formula syntax
+      - run: brew test-bot --only-tap-syntax
+
+      # Builds and tests formulas, formulas are autodetected from the PR
+      - run: brew test-bot --only-formulae --verbose
+        if: github.event_name == 'pull_request'
+
+      - name: Upload bottles to Github Actions
+        uses: actions/upload-artifact@v2
+        with:
+          name: homebrew-bottles
+          path: '*.bottle.*'
+

--- a/Formula/ligo.rb
+++ b/Formula/ligo.rb
@@ -1,11 +1,16 @@
 class Ligo < Formula
-  desc "A friendly Smart Contract Language for Tezos"
+  desc "Friendly Smart Contract Language for Tezos"
   homepage "https://ligolang.org/"
 
-  version "0.19.0"
-  url "https://gitlab.com/ligolang/ligo.git", :tag => Ligo.version, :shallow => true
+  url "https://gitlab.com/ligolang/ligo/-/archive/0.19.0/ligo-0.19.0.tar.gz"
+  # Version is autoscanned from url, we don't specify it explicitly because `brew audit` will complain
+  # To calculate sha256: 'curl -L --fail <url> | sha256sum'
+  sha256 "eeaf549217d3706bc3bc9f9069384ac77e262ed989303da1cdfc66c9dc9ce390"
 
   bottle do
+    root_url "https://github.com/ligolang/homebrew-ligo/releases/download/v#{Ligo.version}"
+    # sha256 cellar: :any, catalina: "5ca59cee439a0c7190258e2b7c5e344ccf21cbf46e9515e4b3cb7f13ecbb106b"
+    # sha256 cellar: :any, mojave:   "1ef88e0c41433946fdb3af1f2f02f528d219d5bb9d818023b3b6d553ce86650f"
   end
 
   build_dependencies = %w[opam rust hidapi pkg-config]
@@ -25,15 +30,17 @@ class Ligo < Formula
      "--auto-setup",
      "--disable-sandboxing"
 
-    # we want to be sure that all steps run in the same shell with evaled opam config
     ENV["LIGO_VERSION"] = Ligo.version
     system "scripts/setup_switch.sh"
+    # we want to be sure that all steps run in the same shell with evaled opam config
     system ["eval $(opam config env)", "scripts/install_vendors_deps.sh", "scripts/build_ligo_local.sh"].join(" && ")
 
+    cp "_build/install/default/bin/ligo", "ligo"
     bin.mkpath
-    bin.install "_build/install/default/bin/ligo"
+    bin.install "ligo"
   end
+
   test do
-    system "#{bin}/ligo", "--help"
+    system "#{bin}/ligo", "--help=plain"
   end
 end


### PR DESCRIPTION
Adds Github Actions workflow for building the brew formula on Github's catalina runner, checking it with `brew test-bot`, and exporting a catalina bottle.

After this PR I plan to make a Github release and publish bottles as assets, then users won't have to build the package themselves. Maybe we can also make a workflow to make releases automatic, but making the build work was hard enough already, so I'll release manually for now.