### PR TITLE
Don't use `brew test-bot` in CI and add release instructions

### DIFF
--- a/.github/workflows/brew-test.yml
+++ b/.github/workflows/brew-test.yml
@@ -1,42 +1,20 @@
-# Builds and runs checks on the brew formula.
-# Based on: https://github.com/Homebrew/brew/blob/3.2.2/Library/Homebrew/dev-cmd/tap-new.rb#L63
-
-# To run the checks locally:
-# $ brew tap ligolang/homebrew-ligo
-# $ cd "$(brew --repo ligolang/ligo)"
-# $ git fetch
-# $ git checkout <branch>
-# $ git reset --hard @{upstream}
-# Then you can run `brew test-bot` commands by adding '--tap ligolang/ligo' flag
-
-name: test brew formula
+name: Build homebrew bottle
 on:
   push:
     branches: [master]
   pull_request:
 jobs:
-  brew-test:
+  build-bottle:
     runs-on: macos-10.15
     steps:
-      # Installs/updates homebrew itself, and taps for this repo, `homebrew-core` and `homebrew-test-bot`
-      - name: Set up homebrew taps
-        id: set-up-homebrew
-        uses: homebrew/actions/setup-homebrew@master
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - run: brew test-bot --only-cleanup-before
+      - name: Build and test
+        run: ./scripts/build-bottle.sh
 
-      - run: brew test-bot --only-setup
-
-      # Checks formula syntax
-      - run: brew test-bot --only-tap-syntax
-
-      # Builds and tests formulas, formulas are autodetected from the PR
-      - run: brew test-bot --only-formulae --verbose
-        if: github.event_name == 'pull_request'
-
-      - name: Upload bottles to Github Actions
+      - name: Upload bottle to Github Actions
         uses: actions/upload-artifact@v2
         with:
           name: homebrew-bottles
           path: '*.bottle.*'
-

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ brew install ligolang/ligo/ligo
 ligo --help
 ```
 
+## For maintainers
+
+How to make new releases: [docs/release-creation.md](./docs/release-creation.md)
+
 ## License
 
 [MIT](./LICENSE.md)

--- a/docs/release-creation.md
+++ b/docs/release-creation.md
@@ -1,0 +1,12 @@
+# Making new releases
+
+We are using Github Releases to mark new releases and provide pre-built bottles for users. You can track releases for LIGO itself here: https://gitlab.com/ligolang/ligo/-/releases.
+
+To make a release after updating the formula:
+1. Build a bottle for each macOS version you need.
+
+   For macOS Catalina there is a Github Actions workflow that builds it on Github-hosted runners and exports it as an artifact.
+
+   For any other version you should checkout the repository and run `./scripts/build-bottle.sh` script yourself. If you already have `ligo` formula installed with the same version, you may have to uninstall it first with `brew uninstall ligo`.
+2. Add SHA256 hashes for bottles to the formula.
+3. Make a release in Github, specifying LIGO version as a tag and attaching the bottles.

--- a/scripts/build-bottle.sh
+++ b/scripts/build-bottle.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build
+brew install --formula --build-bottle --verbose ./Formula/ligo.rb
+
+# Test
+brew test ./Formula/ligo.rb
+
+# Produce bottle
+brew bottle --force-core-tap --no-rebuild ./Formula/ligo.rb
+
+# Fix bottle file name
+# https://github.com/Homebrew/brew/pull/4612#commitcomment-29995084
+for bottle in ./*.bottle.*; do
+  mv "$bottle" "${bottle/--/-}"
+done


### PR DESCRIPTION
- Add `build-bottle.sh` script to simplify building the bottle manually.
- Use this script in CI instead of `brew test-bot` to simplify the CI, because behavior and configuration of `brew test-bot` is often hard to understand, and it does not seem much better than simple `brew install` and `brew test` in our case.
- Add instructions on how to make a new release and upload bottles.